### PR TITLE
Add correct 'bower' name for package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Please file issues and pull requests against that repo.
 Install with `bower`:
 
 ```shell
-bower install ui-grid
+bower install angular-ui-grid
 ```
 
 Add `<script>` and `<link>` tags to your `index.html`:


### PR DESCRIPTION
Adding the correct name as specified in the bower.io directory. 
![screen shot 2014-11-05 at 6 08 39 pm](https://cloud.githubusercontent.com/assets/1639187/4928043/d2378e72-6540-11e4-9fd5-4e78487ca2e8.png)
