### PR TITLE
Fix minor bower_components references in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ bower install angular-ui-grid
 Add `<script>` and `<link>` tags to your `index.html`:
 
 ```html
-<link rel="stylesheet" href="/bower_components/ui-grid/ui-grid.css" />
-<script src="/bower_components/ui-grid/ui-grid.js"></script>
+<link rel="stylesheet" href="bower_components/angular-ui-grid/ui-grid.css" />
+<script src="bower_components/angular-ui-grid/ui-grid.js"></script>
 ```
 
 ## Documentation


### PR DESCRIPTION
To save someone who would copy/paste the reference, the bower_components folder name is updated and the leading slash removed.