### PR TITLE
Expand support to Angular 1.5.x.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
   ],
   "ignore": [],
   "dependencies": {
-    "angular": ">=1.2.16 1.4.x"
+    "angular": ">=1.2.16 1.5.x"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This seems to be working fine in our tests for what we're using this for. Any chance of moving this to 1.5.x instead of limiting it to 1.4.x?
